### PR TITLE
 qrb_ros_camera: fix head file issue caused by transport update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ sudo reboot
 Create workspace and clone source code from GitHub:
 
 ```bash
+sudo -i
 mkdir -p ~/ros2_ws/src && cd ~/ros2_ws/src
 git clone https://github.com/quic-qrb-ros/qrb_ros_imu.git
 git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git

--- a/include/qrb_ros_camera/camera_ros2_node.hpp
+++ b/include/qrb_ros_camera/camera_ros2_node.hpp
@@ -10,7 +10,7 @@
 #include "qmmf_ros2_pipeline.hpp"
 #include "qrb_ros_camera/camera_ros2_common.hpp"
 #include "qrb_ros_camera/camera_ros2_config.hpp"
-#include "qrb_ros_transport/type/image.hpp"
+#include "qrb_ros_transport_image_type/image.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #define CAMERA_ROS2_FRAME_ID "cam[%u_%u] id[%u]"

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <depend>image_transport</depend>
   <depend>rclcpp_components</depend>
   <depend>rcutils</depend>
-  <depend>qrb_ros_transport</depend>
+  <depend>qrb_ros_transport_image_type</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
 -in order to no depend on imu node,qrb_transport redesign its
   head file, so camera ros node need to update include head file.
 -add qrb_ros_transport_image_type depend in package.xml
 -add sudo -i to fix colcon build cannot run in bash.